### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.6"
 before_install:
  - sudo apt-get update -qq
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4.6"
+  - "0.12"
 before_install:
  - sudo apt-get update -qq
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "0.10"
 before_install:
  - sudo apt-get update -qq
 before_script:

--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
     "type": "git",
     "url": "git://github.com/noflo/noflo-gpio.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "undefined/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "grunt test"
   },
@@ -34,7 +29,7 @@
     "grunt-noflo-manifest": "^0.1.1",
     "mocha": "~2.5.3"
   },
-  "keywords": [],
+  "keywords": ["noflo"],
   "noflo": {
     "components": {
       "ListenChange": "components/ListenChange.coffee",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "name": "Jon Nordby",
     "email": "jononor@gmail.com"
   },
+  "engines": {
+    "node": "0.10"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/noflo/noflo-gpio.git"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-coffeelint": "~0.0.6",
     "grunt-contrib-coffee": "~0.11.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-mocha-test": "^0.12.4",
+    "grunt-mocha-test": "^0.13.2",
     "grunt-noflo-manifest": "^0.1.1",
     "mocha": "~2.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "~1.9.0",
     "coffee-script": "^1.8.0",
-    "grunt": "~0.4.1",
+    "grunt": "~1.0.1",
     "grunt-coffeelint": "~0.0.6",
     "grunt-contrib-coffee": "~0.11.1",
     "grunt-contrib-watch": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "grunt-noflo-manifest": "^0.1.12",
     "mocha": "~3.2.0"
   },
-  "keywords": ["noflo"],
+  "keywords": [
+    "noflo"
+  ],
   "noflo": {
     "components": {
       "ListenChange": "components/ListenChange.coffee",

--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
   },
   "dependencies": {
     "node-gpio": "^0.1.1",
-    "noflo": "~0.5.0"
+    "noflo": "~0.6.0"
   },
   "devDependencies": {
-    "chai": "~1.9.0",
+    "chai": "~3.5.0",
     "coffee-script": "^1.8.0",
     "grunt": "~0.4.1",
     "grunt-coffeelint": "~0.0.6",
-    "grunt-contrib-coffee": "~0.11.1",
-    "grunt-contrib-watch": "~0.6.1",
+    "grunt-contrib-coffee": "~1.0.0",
+    "grunt-contrib-watch": "~1.0.0",
     "grunt-mocha-test": "^0.12.4",
     "grunt-noflo-manifest": "^0.1.1",
-    "mocha": "~1.21.0"
+    "mocha": "~2.4.5"
   },
   "keywords": [],
   "noflo": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "^0.12.4",
     "grunt-noflo-manifest": "^0.1.1",
-    "mocha": "~2.5.3"
+    "mocha": "~3.2.0"
   },
   "keywords": [],
   "noflo": {

--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
   },
   "dependencies": {
     "node-gpio": "^0.1.1",
-    "noflo": "~0.6.0"
+    "noflo": "0.x >= 0.5"
   },
   "devDependencies": {
     "chai": "~3.5.0",
-    "coffee-script": "^1.8.0",
+    "coffee-script": "^1.11.1",
     "grunt": "~1.0.1",
-    "grunt-coffeelint": "~0.0.6",
+    "grunt-coffeelint": "^0.0.16",
     "grunt-contrib-coffee": "~1.0.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-mocha-test": "^0.13.2",
-    "grunt-noflo-manifest": "^0.1.1",
+    "grunt-noflo-manifest": "^0.1.12",
     "mocha": "~3.2.0"
   },
   "keywords": ["noflo"],


### PR DESCRIPTION
Build fails currently due to #1. We could temporarily go to legacy Node.js 